### PR TITLE
docs: update README to use named export instead of default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn add @unleash/proxy-client-vue
 Import the provider like this in your entrypoint file (typically App.vue):
 
 ```jsx
-import FlagProvider from '@unleash/proxy-client-vue'
+import { FlagProvider } from '@unleash/proxy-client-vue'
 
 const config = {
   url: 'https://HOSTNAME/proxy',
@@ -39,7 +39,7 @@ const config = {
 Alternatively, you can pass your own client in to the FlagProvider:
 
 ```jsx
-import FlagProvider, { UnleashClient } from '@unleash/proxy-client-vue'
+import { FlagProvider, UnleashClient } from '@unleash/proxy-client-vue'
 
 const config = {
   url: 'https://HOSTNAME/proxy',


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Updated the README to specify using the named FlagProvider export instead of the default export, which was causing issues with Vite prod builds. 

Keeps proxy-client usage consistent with `proxy-client-react`. See: https://github.com/Unleash/proxy-client-react/pull/58

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
 - `README.md`


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
We might want to remove the default export at a later major version and only use named exports.
