### PR TITLE
feat: unsubscribe event listeners on component unmount

### DIFF
--- a/src/useFlag.ts
+++ b/src/useFlag.ts
@@ -1,19 +1,27 @@
-import { ref, inject } from 'vue'
+import { ref, inject, onUnmounted } from 'vue'
 import { ContextStateSymbol } from './context'
 
 const useFlag = (name: string) => {
   const { isEnabled, client } = inject(ContextStateSymbol) || {}
   const flag = ref(!!isEnabled.value(name))
 
-  client.value.on('update', () => {
+  function onUpdate() {
     const enabled = isEnabled.value(name)
     if (enabled !== flag.value) {
       flag.value = !!enabled
     }
-  })
+  }
 
-  client.value.on('ready', () => {
+  function onReady() {
     flag.value = isEnabled.value(name)
+  }
+
+  client.value.on('ready', onReady)
+  client.value.on('update', onUpdate)
+
+  onUnmounted(() => {
+    client.value.off('ready', onReady)
+    client.value.off('update', onUpdate)
   })
 
   return flag

--- a/src/useVariant.ts
+++ b/src/useVariant.ts
@@ -1,11 +1,11 @@
-import { ref, inject } from 'vue'
+import { ref, inject, onUnmounted } from 'vue'
 import { ContextStateSymbol } from './context'
 
 const useVariant = (name: string) => {
   const { getVariant, client } = inject(ContextStateSymbol) || {}
   const variant = ref(getVariant.value(name))
 
-  client.value.on('update', () => {
+  function onUpdate() {
     const newVariant = getVariant.value(name)
     if (
       newVariant.name !== variant.value.name ||
@@ -13,10 +13,18 @@ const useVariant = (name: string) => {
     ) {
       variant.value = newVariant
     }
-  })
+  }
 
-  client.value.on('ready', () => {
+  function onReady() {
     variant.value = getVariant.value(name)
+  }
+
+  client.value.on('ready', onReady)
+  client.value.on('update', onUpdate)
+
+  onUnmounted(() => {
+    client.value.off('ready', onReady)
+    client.value.off('update', onUpdate)
   })
 
   return variant || {}


### PR DESCRIPTION
While using this package I noticed that the events used on useFlag and useVariant are only getting registered but not unsubscribed when the component using the composable unloads.

## About the changes
This PR changes a bit both of the composables to have the registration of the events and unregister them on the onUnmounted lifecycle hook.