### PR TITLE
Install as plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ const config = {
 
 const app = createApp(App)
 app.use(unleashPlugin, { config })
+app.mount('#app')
 ```
 
 Or use the FlagProvider component like this in your entrypoint file (typically App.vue):
@@ -76,6 +77,7 @@ const client = new UnleashClient(config)
 
 const app = createApp(App)
 app.use(unleashPlugin, { unleashClient: client })
+app.mount('#app')
 ```
 
 Or, using FlagProvider:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,27 @@ yarn add @unleash/proxy-client-vue
 
 # Initialization
 
-Import the provider like this in your entrypoint file (typically App.vue):
+## Using config:
+
+```jsx
+import { createApp } from 'vue'
+import { plugin as unleashPlugin } from '@unleash/proxy-client-vue'
+// import the root component App from a single-file component.
+import App from './App.vue'
+
+const config = {
+  url: 'https://HOSTNAME/proxy',
+  clientKey: 'PROXYKEY',
+  refreshInterval: 15,
+  appName: 'your-app-name',
+  environment: 'dev'
+}
+
+const app = createApp(App)
+app.use(unleashPlugin, { config })
+```
+
+Or use the FlagProvider component like this in your entrypoint file (typically App.vue):
 
 ```jsx
 import { FlagProvider } from '@unleash/proxy-client-vue'
@@ -36,7 +56,29 @@ const config = {
 </template>
 ```
 
-Alternatively, you can pass your own client in to the FlagProvider:
+## Initializing your own client
+
+```jsx
+import { createApp } from 'vue'
+import { plugin as unleashPlugin } from '@unleash/proxy-client-vue'
+// import the root component App from a single-file component.
+import App from './App.vue'
+
+const config = {
+  url: 'https://HOSTNAME/proxy',
+  clientKey: 'PROXYKEY',
+  refreshInterval: 15,
+  appName: 'your-app-name',
+  environment: 'dev'
+}
+
+const client = new UnleashClient(config)
+
+const app = createApp(App)
+app.use(unleashPlugin, { unleashClient: client })
+```
+
+Or, using FlagProvider:
 
 ```jsx
 import { FlagProvider, UnleashClient } from '@unleash/proxy-client-vue'

--- a/src/FlagProvider.vue
+++ b/src/FlagProvider.vue
@@ -1,13 +1,22 @@
 <script setup lang="ts">
 import { onMounted, provide } from 'vue'
+import { UnleashClient, IConfig } from "unleash-proxy-client"
+
 import { ContextStateSymbol, ContextUpdateSymbol } from './context'
-import useUnleashProvide, { IProvideOptions } from './useUnleashProvide';
+import useUnleashProvide from './useUnleashProvide';
+
+
 
 const {
   config,
   unleashClient,
   startClient = true
-} = defineProps<IProvideOptions>()
+  // duplicated props because of https://github.com/vuejs/core/issues/4294
+} = defineProps<{
+  config?: IConfig
+  unleashClient?: UnleashClient
+  startClient?: boolean
+}>()
 
 const { context, start, update } = useUnleashProvide({ config, unleashClient, startClient })
 

--- a/src/FlagProvider.vue
+++ b/src/FlagProvider.vue
@@ -1,74 +1,23 @@
 <script setup lang="ts">
-import { ref, onMounted, reactive, provide, toRefs } from 'vue'
+import { onMounted, provide } from 'vue'
 import { ContextStateSymbol, ContextUpdateSymbol } from './context'
-import { UnleashClient, IConfig, IContext } from 'unleash-proxy-client'
-
-type eventArgs = [Function, any]
+import useUnleashProvide, { IProvideOptions } from './useUnleashProvide';
 
 const {
   config,
   unleashClient,
   startClient = true
-} = defineProps<{
-  config?: IConfig
-  unleashClient?: UnleashClient
-  startClient?: boolean
-}>()
+} = defineProps<IProvideOptions>()
 
-const client = ref<UnleashClient | undefined>(unleashClient)
-const flagsReady = ref(false)
-const flagsError = ref(null)
+const { context, start, update } = useUnleashProvide({ config, unleashClient, startClient })
 
-if (!config && !unleashClient) {
-  console.warn(
-    `You must provide either a config or an unleash client to the flag provider. If you are initializing the client in useEffect, you can avoid this warning by
-      checking if the client exists before rendering.`
-  )
-}
+provide(ContextStateSymbol, context)
+provide(ContextUpdateSymbol, update)
 
-if (!client.value && config) {
-  client.value = new UnleashClient(config)
-}
-
-client.value?.on('ready', () => {
-  flagsReady.value = true
-})
-
-client.value?.on('error', (e: any) => {
-  flagsError.value = e
-})
 
 onMounted(() => {
-  const shouldStartClient = startClient || !unleashClient
-  if (shouldStartClient) client.value?.start()
+  start()
 })
-
-const updateContext = async (context: IContext): Promise<void> => {
-  await client.value?.updateContext(context)
-}
-
-const isEnabled = (name: string) => client.value?.isEnabled(name)
-const getVariant = (name: string) => client.value?.getVariant(name)
-const on = (event: string, ...args: eventArgs) =>
-  client.value?.on(event, ...args)
-
-const context = reactive({
-  on,
-  updateContext,
-  isEnabled,
-  getVariant,
-  client,
-  flagsReady,
-  flagsError
-}) as { [key: string]: any }
-
-provide(ContextStateSymbol, toRefs(context))
-
-const update = (property: string, value: any) => {
-  context[property] = value
-}
-
-provide(ContextUpdateSymbol, update)
 </script>
 
 <template>

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import useFlagsStatus from './useFlagsStatus'
 import useVariant from './useVariant'
 import useUnleashContext from './useUnleashContext'
 import useUnleashClient from './useUnleashClient'
+import plugin from './plugin'
 
 export {
   ContextStateSymbol,
@@ -28,7 +29,8 @@ export {
   useFlagsStatus,
   useVariant,
   useUnleashContext,
-  useUnleashClient
+  useUnleashClient,
+  plugin
 }
 
 export default FlagProvider

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,17 @@
+import { App } from 'vue'
+import { ContextStateSymbol, ContextUpdateSymbol } from './context'
+import useUnleashProvide, { IProvideOptions } from './useUnleashProvide'
+
+
+const plugin = {
+  install(app: App, { config, unleashClient, startClient }: IProvideOptions) {
+    const { context, update, start } = useUnleashProvide({ config, unleashClient, startClient })
+
+    app.provide(ContextStateSymbol, context)
+    app.provide(ContextUpdateSymbol, update)
+
+    start()
+  }
+}
+
+export default plugin

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,9 +1,9 @@
-import { App } from 'vue'
+import { App, Plugin } from 'vue'
 import { ContextStateSymbol, ContextUpdateSymbol } from './context'
 import useUnleashProvide, { IProvideOptions } from './useUnleashProvide'
 
 
-const plugin = {
+const plugin: Plugin = {
   install(app: App, { config, unleashClient, startClient }: IProvideOptions) {
     const { context, update, start } = useUnleashProvide({ config, unleashClient, startClient })
 

--- a/src/useUnleashProvide.ts
+++ b/src/useUnleashProvide.ts
@@ -1,0 +1,76 @@
+import { ref, reactive, toRefs } from 'vue'
+import { UnleashClient, IConfig, IContext } from "unleash-proxy-client"
+
+type eventArgs = [Function, any]
+
+export interface IProvideOptions {
+  config?: IConfig
+  unleashClient?: UnleashClient
+  startClient?: boolean
+}
+
+function useUnleashProvide({
+  config,
+  unleashClient,
+  startClient = true
+}: IProvideOptions) {
+  const client = ref<UnleashClient | undefined>(unleashClient)
+  const flagsReady = ref(false)
+  const flagsError = ref(null)
+
+  if (!config && !unleashClient) {
+    console.warn(
+      `You must provide either a config or an unleash client to the flag provider. If you are initializing the client in useEffect, you can avoid this warning by
+    checking if the client exists before rendering.`
+    )
+  }
+
+  if (!client.value && config) {
+    client.value = new UnleashClient(config)
+  }
+
+  client.value?.on('ready', () => {
+    flagsReady.value = true
+  })
+
+  client.value?.on('error', (e: any) => {
+    flagsError.value = e
+  })
+
+  const updateContext = async (context: IContext): Promise<void> => {
+    await client.value?.updateContext(context)
+  }
+
+  const isEnabled = (name: string) => client.value?.isEnabled(name)
+  const getVariant = (name: string) => client.value?.getVariant(name)
+  const on = (event: string, ...args: eventArgs) =>
+    client.value?.on(event, ...args)
+
+  const context = reactive({
+    on,
+    updateContext,
+    isEnabled,
+    getVariant,
+    client,
+    flagsReady,
+    flagsError,
+  }) as { [key: string]: any }
+
+  const update = (property: string, value: any) => {
+    context[property] = value
+  }
+
+  const start = () => {
+    if (startClient || !unleashClient) {
+      client?.value?.start()
+    }
+  }
+
+  return {
+    context: toRefs(context),
+    update,
+    start
+  }
+}
+
+export default useUnleashProvide


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
Deleted the FlagProvider component and instead added option to install as a vue plugin. All the logic from the component is copied to the plugin. 
Things that changed:
- all provides are now scoped to the app using app.provide instead of provide imported from vue
- onMounted is deleted, and client starts on plugin install - not sure if that would be a problem

<!-- Does it close an issue? Multiple? -->
Closes #11 

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
plugin.ts

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Is it a problem if client.start is called on plugin install?