### PR TITLE
docs: update readme: front-end API and environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,10 @@ Or use the FlagProvider component like this in your entrypoint file (typically A
 import { FlagProvider } from '@unleash/proxy-client-vue'
 
 const config = {
-  url: 'https://HOSTNAME/proxy',
-  clientKey: 'PROXYKEY',
+  url: 'https://UNLEASH-INSTANCE/api/frontend',
+  clientKey: 'CLIENT—SIDE—API—TOKEN',
   refreshInterval: 15,
   appName: 'your-app-name',
-  environment: 'dev'
 }
 
 <template>
@@ -86,11 +85,10 @@ Or, using FlagProvider:
 import { FlagProvider, UnleashClient } from '@unleash/proxy-client-vue'
 
 const config = {
-  url: 'https://HOSTNAME/proxy',
-  clientKey: 'PROXYKEY',
+  url: 'https://UNLEASH-INSTANCE/api/frontend',
+  clientKey: 'CLIENT—SIDE—API—TOKEN',
   refreshInterval: 15,
   appName: 'your-app-name',
-  environment: 'dev'
 }
 
 const client = new UnleashClient(config)


### PR DESCRIPTION
This change makes the examples connect to the front-end API instead of
to the proxy. We want to push people towards using the front-end API
first, so changing the examples is a good place to start.

It also removes the `environment` property from initialization. This
property is (should be?) deprecated and generally just serves to confuse users, so
by removing it from the  examples, we can probably avoid a bit of confusion.