### PR TITLE
docs: remove `environment` from code samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ const config = {
   clientKey: 'PROXYKEY',
   refreshInterval: 15,
   appName: 'your-app-name',
-  environment: 'dev'
 }
 
 const app = createApp(App)
@@ -69,7 +68,6 @@ const config = {
   clientKey: 'PROXYKEY',
   refreshInterval: 15,
   appName: 'your-app-name',
-  environment: 'dev'
 }
 
 const client = new UnleashClient(config)


### PR DESCRIPTION
This doesn't do what people expect it to and it's not required for the
config, so let's remove it.