### PR TITLE
feat: expose ready promise in composable

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,2 +1,3 @@
 export const ContextStateSymbol = Symbol('Context state identifier')
 export const ContextUpdateSymbol = Symbol('Context update identifier')
+export const ContextReadySymbol = Symbol('Context ready identifier')

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,16 +12,22 @@ export {
   InMemoryStorageProvider
 } from 'unleash-proxy-client'
 
-import { ContextStateSymbol, ContextUpdateSymbol } from './context'
+import {
+  ContextReadySymbol,
+  ContextStateSymbol,
+  ContextUpdateSymbol
+} from './context'
 import FlagProvider from './FlagProvider.vue'
 import useFlag from './useFlag'
 import useFlagsStatus from './useFlagsStatus'
 import useVariant from './useVariant'
 import useUnleashContext from './useUnleashContext'
 import useUnleashClient from './useUnleashClient'
+import useUnleashClientReady from './useUnleashClientReady'
 import plugin from './plugin'
 
 export {
+  ContextReadySymbol,
   ContextStateSymbol,
   ContextUpdateSymbol,
   FlagProvider,
@@ -30,6 +36,7 @@ export {
   useVariant,
   useUnleashContext,
   useUnleashClient,
+  useUnleashClientReady,
   plugin
 }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,9 @@
-import { App, Plugin } from 'vue'
-import { ContextStateSymbol, ContextUpdateSymbol } from './context'
+import { App, Plugin, ref } from 'vue'
+import {
+  ContextReadySymbol,
+  ContextStateSymbol,
+  ContextUpdateSymbol
+} from './context'
 import useUnleashProvide, { IProvideOptions } from './useUnleashProvide'
 
 const plugin: Plugin = {
@@ -13,8 +17,10 @@ const plugin: Plugin = {
     app.provide(ContextStateSymbol, context)
     app.provide(ContextUpdateSymbol, update)
 
-    start()
-  }
+    const isReady = ref(start())
+
+    app.provide(ContextReadySymbol, isReady)
+  },
 }
 
 export default plugin

--- a/src/useUnleashClientReady.ts
+++ b/src/useUnleashClientReady.ts
@@ -1,0 +1,15 @@
+import { inject, ref, Ref } from 'vue'
+import { ContextReadySymbol } from './context'
+
+type TUnleashClientStatus = Ref<Promise<void>>
+
+const useUnleashClientReady = () => {
+  const isReady = inject<TUnleashClientStatus>(
+    ContextReadySymbol,
+    ref(new Promise(() => {}))
+  )
+
+  return isReady?.value
+}
+
+export default useUnleashClientReady

--- a/src/useUnleashProvide.ts
+++ b/src/useUnleashProvide.ts
@@ -62,7 +62,7 @@ function useUnleashProvide({
 
   const start = () => {
     if (startClient || !unleashClient) {
-      client?.value?.start()
+      return client?.value?.start()
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
This PR comes from a use case where I need my analytics solution to always report the up-to-date state of my feature toggles. I know there are already events fired for `ready` and `update`, but the `start` method of the Unleash client already [returns a promise](https://github.com/Unleash/unleash-proxy-client-js/blob/main/src/index.ts#L303) and it's much simpler to use that. I just made a new composable that returns it.

<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
It's all about `src/useUnleashClientReady.ts`.

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
I haven't exposed the ready state in `src/FlagProvider.vue` - I hope that doesn't stop this PR from getting merged.