### PR TITLE
feat: add feature_enabled property to variant response

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "unleash-proxy-client": "^2.5.0",
+    "unleash-proxy-client": "^3.2.0",
     "vue": "^3.2.45"
   },
   "devDependencies": {

--- a/src/useVariant.ts
+++ b/src/useVariant.ts
@@ -7,16 +7,27 @@ type TVariantContext = Partial<{
   client: Ref<UnleashClient>
 }>
 
+const variantHasChanged = (
+  oldVariant?: IVariant,
+  newVariant?: IVariant
+): boolean => {
+  const variantsAreEqual =
+    oldVariant?.name === newVariant?.name &&
+    oldVariant?.enabled === newVariant?.enabled &&
+    oldVariant?.feature_enabled === newVariant?.feature_enabled &&
+    oldVariant?.payload?.type === newVariant?.payload?.type &&
+    oldVariant?.payload?.value === newVariant?.payload?.value
+
+  return !variantsAreEqual
+}
+
 const useVariant = (name: string) => {
   const { getVariant, client } = inject<TVariantContext>(ContextStateSymbol, {})
   const variant = ref(getVariant?.value(name))
 
   function onUpdate() {
     const newVariant = getVariant?.value(name)
-    if (
-      newVariant?.name !== variant.value?.name ||
-      newVariant?.enabled !== variant.value?.enabled
-    ) {
+    if (variantHasChanged(variant?.value, newVariant)) {
       variant.value = newVariant
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,13 +897,13 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
-unleash-proxy-client@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-2.5.0.tgz#0f4f34285bc3223023ca2cf3ef9dabd2132eea9f"
-  integrity sha512-GWYLcQDW2UVhqAVwZX7jNzD6Lp96UJXEi66r9MiDd/C3Xw7rbTdFziNJAhEZpLNqR7j75+TfZaEYMCMy/k778g==
+unleash-proxy-client@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.2.0.tgz#cdecf1b3bdd40fbe7a20fd66c27906b33e53c4fd"
+  integrity sha512-y9iCRCytxQCej6HlXecGu63ul1Wz6xklXOs+vuaPbqtj4NDGT6IThUvP3h7m5pW+IIxR99hnkVS1FICt1FT3yQ==
   dependencies:
     tiny-emitter "^2.1.0"
-    uuid "^8.3.2"
+    uuid "^9.0.1"
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -912,10 +912,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 validator@^13.7.0:
   version "13.7.0"


### PR DESCRIPTION
Bumps `unleash-proxy-client` to `3.2.0` and makes the necessary adjustments for the new "feature_enabled" property, similar to https://github.com/Unleash/proxy-client-svelte/pull/15