### PR TITLE
chore: change the env var name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,5 @@ jobs:
       version: ${{ github.event.inputs.version }}
       tag: ${{ github.event.inputs.tag }}
     secrets:
-      GH_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+      GH_ACCESS_TOKEN: ${{ secrets.GH_TOKEN}}
       NPM_ACCESS_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
github no longer allows secrets starting with GITHUB