### PR TITLE
fix: export default last

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/index.es.js",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.es.js"
       },
       "require": {
-        "default": "./dist/index.umd.js",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.umd.js"
       }
     }
   },


### PR DESCRIPTION
Moves "default" in exports to last, which should fix: https://github.com/Unleash/proxy-client-vue/issues/30