### PR TITLE
feat: add sdk uniqueness headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "unleash-proxy-client": "^3.2.0",
+    "unleash-proxy-client": "^3.7.1",
     "vue": "^3.2.45"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,10 +897,10 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
-unleash-proxy-client@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.2.0.tgz#cdecf1b3bdd40fbe7a20fd66c27906b33e53c4fd"
-  integrity sha512-y9iCRCytxQCej6HlXecGu63ul1Wz6xklXOs+vuaPbqtj4NDGT6IThUvP3h7m5pW+IIxR99hnkVS1FICt1FT3yQ==
+unleash-proxy-client@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.1.tgz#c51483aebaad664e6d6ea70828f5f10bece61a40"
+  integrity sha512-ri3cauGfQBjvRvwwJIQfnHlpOfFvQz0iy5hVd82Tr4t0LkqpqFr248tuO8jkI39JXelUcX7TCGNHneeMMPZM1A==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"


### PR DESCRIPTION
Updates the dependency on the underlying Unleash client to 3.7.1. This
version of the client adds new x-unleash headers which lets Unleash
count unique connections and see SDK version information.