### PR TITLE
fix: update proxy client dep to 3.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "unleash-proxy-client": "^3.7.1",
+    "unleash-proxy-client": "^3.7.2",
     "vue": "^3.2.45"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,10 +897,10 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
-unleash-proxy-client@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.1.tgz#c51483aebaad664e6d6ea70828f5f10bece61a40"
-  integrity sha512-ri3cauGfQBjvRvwwJIQfnHlpOfFvQz0iy5hVd82Tr4t0LkqpqFr248tuO8jkI39JXelUcX7TCGNHneeMMPZM1A==
+unleash-proxy-client@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.2.tgz#c6166bbaf293f8dea12cf65d061d72234c5b76a8"
+  integrity sha512-1SvHsl3kQh1DT9EKMQsN9alOvXZEz9hpxa3mG6QWtTmXJqa6VZi25dQ2U8Y2KAULKg6ARLMUQkod74Fe/pKp0g==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"


### PR DESCRIPTION
This update includes uuid generation that doesn't rely on the `crypto` module for connection id.