### PR TITLE
fix: set vue as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "unleash-proxy-client": "^3.7.2",
+    "unleash-proxy-client": "^3.7.2"
+  },
+  "peerDependencies": {
     "vue": "^3.2.45"
   },
   "devDependencies": {
@@ -42,6 +44,7 @@
     "typescript": "^4.5.4",
     "vite": "^2.9.2",
     "vite-plugin-dts": "^1.6.4",
-    "vue-tsc": "^1.0.10"
+    "vue-tsc": "^1.0.10",
+    "vue": "^3.2.45"
   }
 }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3179/make-vue-a-peer-dependency

Sets Vue as a peer dependency. 

Should fix #35 — Thank you again for raising the issue @johannes-lindgren!