### PR TITLE
fix: use IMutableContext when updating context

### DIFF
--- a/src/useUnleashContext.ts
+++ b/src/useUnleashContext.ts
@@ -1,9 +1,9 @@
-import { IContext } from 'unleash-proxy-client'
+import { IMutableContext } from 'unleash-proxy-client'
 import { inject, Ref } from 'vue'
 import { ContextStateSymbol } from './context'
 
 type TUnleashContext = Partial<{
-  updateContext: Ref<(context: IContext) => Promise<void>>
+  updateContext: Ref<(context: IMutableContext) => Promise<void>>
 }>
 
 const useUnleashContext = () => {

--- a/src/useUnleashProvide.ts
+++ b/src/useUnleashProvide.ts
@@ -1,5 +1,5 @@
 import { ref, reactive, toRefs } from 'vue'
-import { UnleashClient, IConfig, IContext } from 'unleash-proxy-client'
+import { UnleashClient, IConfig, IMutableContext } from 'unleash-proxy-client'
 
 type eventArgs = [Function, any]
 
@@ -37,7 +37,7 @@ function useUnleashProvide({
     flagsError.value = e
   })
 
-  const updateContext = async (context: IContext): Promise<void> => {
+  const updateContext = async (context: IMutableContext): Promise<void> => {
     await client.value?.updateContext(context)
   }
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3762/proper-frontend-sdk-name-reporting

Updates the type in `updateContext` to use `IMutableContext`.

Follow-up to: https://github.com/Unleash/unleash-svelte-sdk/pull/28